### PR TITLE
🛠️ fix(observability): stabilize loki and grafana crash loops

### DIFF
--- a/clusters/r4spi/apps/lgtm-grafana.yaml
+++ b/clusters/r4spi/apps/lgtm-grafana.yaml
@@ -14,6 +14,26 @@ spec:
       valuesObject:
         replicas: 1
 
+        deploymentStrategy:
+          type: Recreate
+
+        envValueFrom:
+          GF_DATABASE_USER:
+            secretKeyRef:
+              name: grafana-pg-app
+              key: username
+          GF_DATABASE_PASSWORD:
+            secretKeyRef:
+              name: grafana-pg-app
+              key: password
+
+        grafana.ini:
+          database:
+            type: postgres
+            host: grafana-pg-rw.observability:5432
+            name: grafana
+            ssl_mode: require
+
         ingress:
           enabled: true
           ingressClassName: nginx
@@ -89,6 +109,26 @@ spec:
               gnetId: 1860
               revision: 37
               datasource: Prometheus
+
+        extraResources:
+          - apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+            metadata:
+              name: grafana-pg
+            spec:
+              instances: 3
+              storage:
+                size: 2Gi
+              bootstrap:
+                initdb:
+                  database: grafana
+                  owner: grafana
+              failoverDelay: 30
+              postgresql:
+                parameters:
+                  wal_sender_timeout: 60s
+                  wal_receiver_timeout: 60s
+                  wal_keep_size: 2048MB
 
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/r4spi/apps/lgtm-loki.yaml
+++ b/clusters/r4spi/apps/lgtm-loki.yaml
@@ -30,6 +30,10 @@ spec:
                   prefix: loki_index_
                   period: 24h
 
+        sidecar:
+          rules:
+            enabled: false
+
         singleBinary:
           replicas: 1
           persistence:

--- a/helm/grafana/grafana-10.5.15/templates/extra-resources.yaml
+++ b/helm/grafana/grafana-10.5.15/templates/extra-resources.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraResources }}
+---
+{{- if typeIs "string" . }}
+  {{- tpl . $ }}
+{{- else }}
+  {{- tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/helm/grafana/grafana-10.5.15/values.yaml
+++ b/helm/grafana/grafana-10.5.15/values.yaml
@@ -1705,3 +1705,23 @@ extraObjects: []
 # Alternatively, if you wish to allow secret values to be exposed in the rendered grafana.ini configmap,
 # you can disable this check by setting assertNoLeakedSecrets to false.
 assertNoLeakedSecrets: true
+
+# -- Extra resources to deploy with the chart.
+# Supports both object and string (multiline) formats. Helm template expressions are evaluated.
+extraResources: []
+  # Object format:
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: example-configmap
+  #     namespace: "{{ .Release.Namespace }}"
+  #   data:
+  #     example-key: example-value
+  #
+  # String format (multiline):
+  # - |
+  #   apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: example-configmap
+  #     namespace: "{{ .Release.Namespace }}"


### PR DESCRIPTION
## Why

After the LGTM stack landed (#30), two pods in the `observability` namespace crash-looped:

- **`loki-0`** — the main `loki` container was healthy, but the `loki-sc-rules` sidecar (k8s-sidecar) crash-looped with `SSLCertVerificationError: CA cert does not include key usage extension`. The MicroK8s API server's self-signed CA lacks the `keyUsage` extension, which the sidecar image's newer Python `ssl` stack now strictly enforces. This is a MicroK8s/Python incompatibility, not a Loki misconfiguration.
- **`grafana`** — failed DB migration with `database is locked`. Two compounding causes: a RollingUpdate left two pods briefly sharing the same RWO PVC on one node, and SQLite on the NFS-backed `subdir-usb` storage class handles file locking poorly.

## What

- **Loki:** disable the rules sidecar (`sidecar.rules.enabled: false`). No Loki alerting/recording rules are in use, so the sidecar serves no purpose here.
- **Grafana:** move off NFS-backed SQLite onto Postgres.
  - Provision a CloudNativePG `Cluster` (`grafana-pg`, 3 instances) via `extraResources`, following the same pattern as `open-webui`.
  - Point Grafana at it through `grafana.ini [database]` (type `postgres`, host `grafana-pg-rw`), with the user/password injected from the CNPG-generated `grafana-pg-app` secret via `envValueFrom`.
  - Switch the Deployment to the `Recreate` strategy so only one pod runs at a time.
- **Chart:** add `extraResources` support to the vendored `grafana` chart (template + values), consistent with the repo's other charts.

## Notes

- Credentials are not hardcoded; they come from the CNPG-managed secret.
- Grafana starts against a fresh empty Postgres database, so it re-runs migrations cleanly. The old SQLite PVC is simply no longer used as the backing store.
- Validated locally with `helm template` for both apps: the Loki StatefulSet no longer renders the `loki-sc-rules` container, and Grafana renders the CNPG `Cluster`, `Recreate` strategy, Postgres `[database]` config, and `GF_DATABASE_*` env from the secret.