### PR TITLE
fix(prometheus): force server-side apply for Prometheus Operator CRDs

### DIFF
--- a/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-alertmanagerconfigs.yaml
+++ b/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-alertmanagerconfigs.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.20.1
     operator.prometheus.io/version: 0.91.0
   name: alertmanagerconfigs.monitoring.coreos.com

--- a/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-alertmanagers.yaml
+++ b/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-alertmanagers.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.20.1
     operator.prometheus.io/version: 0.91.0
   name: alertmanagers.monitoring.coreos.com

--- a/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-podmonitors.yaml
+++ b/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-podmonitors.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.20.1
     operator.prometheus.io/version: 0.91.0
   name: podmonitors.monitoring.coreos.com

--- a/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-probes.yaml
+++ b/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-probes.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.20.1
     operator.prometheus.io/version: 0.91.0
   name: probes.monitoring.coreos.com

--- a/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-prometheusagents.yaml
+++ b/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-prometheusagents.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.20.1
     operator.prometheus.io/version: 0.91.0
   name: prometheusagents.monitoring.coreos.com

--- a/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-prometheuses.yaml
+++ b/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-prometheuses.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.20.1
     operator.prometheus.io/version: 0.91.0
   name: prometheuses.monitoring.coreos.com

--- a/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-prometheusrules.yaml
+++ b/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-prometheusrules.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.20.1
     operator.prometheus.io/version: 0.91.0
   name: prometheusrules.monitoring.coreos.com

--- a/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-scrapeconfigs.yaml
+++ b/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-scrapeconfigs.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.20.1
     operator.prometheus.io/version: 0.91.0
   name: scrapeconfigs.monitoring.coreos.com

--- a/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-servicemonitors.yaml
+++ b/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-servicemonitors.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.20.1
     operator.prometheus.io/version: 0.91.0
   name: servicemonitors.monitoring.coreos.com

--- a/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-thanosrulers.yaml
+++ b/helm/prometheus/kube-prometheus-stack-86.2.0/charts/crds/crds/crd-thanosrulers.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.20.1
     operator.prometheus.io/version: 0.91.0
   name: thanosrulers.monitoring.coreos.com


### PR DESCRIPTION
## Summary
- 6 of 10 Prometheus Operator CRDs (`prometheuses`, `alertmanagers`, `alertmanagerconfigs`, `prometheusagents`, `scrapeconfigs`, `thanosrulers`) exceeded the 262144-byte `last-applied-configuration` annotation limit under client-side apply, leaving them unregistered and the actual Prometheus/Alertmanager server pods never created
- Add `argocd.argoproj.io/sync-options: ServerSideApply=true` to all 10 CRDs in the `crds` subchart (including the 4 currently-passing ones, so future chart bumps that grow them past the limit don't regress the same way)

## Test plan
- [x] Verified `prometheuses.monitoring.coreos.com` / `alertmanagers.monitoring.coreos.com` CRDs were missing from the live cluster, matching the ArgoCD sync error (`metadata.annotations: Too long`)
- [x] Manually applied the two missing CRDs via `kubectl apply --server-side` to confirm this resolves the registration issue
- [x] Validated all 10 modified CRD YAML files parse correctly (`yq`)
- [ ] After merge: ArgoCD sync on `prometheus` Application should reach `Synced`/`Healthy` and the `prometheus-kube-prometheus-prometheus-0` / alertmanager pods should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfKDWuUnJDKCFH2MVUeFmV