### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/helm/litellm/litellm-1.83.7-stable.patch.1/charts/postgresql/values.yaml
+++ b/helm/litellm/litellm-1.83.7-stable.patch.1/charts/postgresql/values.yaml
@@ -1378,8 +1378,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r16
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/helm/litellm/litellm-1.83.7-stable.patch.1/charts/redis/values.yaml
+++ b/helm/litellm/litellm-1.83.7-stable.patch.1/charts/redis/values.yaml
@@ -1971,8 +1971,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r16
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -2073,8 +2073,8 @@ sysctl:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r16
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/helm/litellm/litellm-1.83.7-stable.patch.1/templates/tests/test-servicemonitor.yaml
+++ b/helm/litellm/litellm-1.83.7-stable.patch.1/templates/tests/test-servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
     - name: test
-      image: bitnami/kubectl:latest
+      image: soldevelo/kubectl:latest
       command: ['sh', '-c']
       args:
         - |

--- a/helm/litellm/litellm-1.87.1/charts/postgresql/values.yaml
+++ b/helm/litellm/litellm-1.87.1/charts/postgresql/values.yaml
@@ -1378,8 +1378,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r16
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/helm/litellm/litellm-1.87.1/charts/redis/values.yaml
+++ b/helm/litellm/litellm-1.87.1/charts/redis/values.yaml
@@ -1971,8 +1971,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r16
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -2073,8 +2073,8 @@ sysctl:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r16
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/helm/litellm/litellm-1.87.1/templates/tests/test-servicemonitor.yaml
+++ b/helm/litellm/litellm-1.87.1/templates/tests/test-servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
     - name: test
-      image: bitnami/kubectl:latest
+      image: soldevelo/kubectl:latest
       command: ['sh', '-c']
       args:
         - |

--- a/helm/litellm/litellm-1.89.4/charts/postgresql/values.yaml
+++ b/helm/litellm/litellm-1.89.4/charts/postgresql/values.yaml
@@ -1378,8 +1378,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r16
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/helm/litellm/litellm-1.89.4/charts/redis/values.yaml
+++ b/helm/litellm/litellm-1.89.4/charts/redis/values.yaml
@@ -1971,8 +1971,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r16
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -2073,8 +2073,8 @@ sysctl:
   ##
   image:
     registry: docker.io
-    repository: bitnami/os-shell
-    tag: 12-debian-12-r16
+    repository: soldevelo/os-shell
+    tag: 12-debian-12-r3
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/helm/litellm/litellm-1.89.4/templates/tests/test-servicemonitor.yaml
+++ b/helm/litellm/litellm-1.89.4/templates/tests/test-servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
     - name: test
-      image: bitnami/kubectl:latest
+      image: soldevelo/kubectl:latest
       command: ['sh', '-c']
       args:
         - |


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/kubectl:latest` → [`soldevelo/kubectl:latest`](https://hub.docker.com/r/soldevelo/kubectl)
- `bitnami/os-shell:12-debian-12-r16` → [`soldevelo/os-shell:12-debian-12-r3`](https://hub.docker.com/r/soldevelo/os-shell)